### PR TITLE
Replace double with CGFloat

### DIFF
--- a/CCMBorderView/Objective-C/CCMBorderView.h
+++ b/CCMBorderView/Objective-C/CCMBorderView.h
@@ -35,7 +35,7 @@ typedef NS_OPTIONS(NSInteger, Border){
 @property IBInspectable BOOL      borderLeft;
 @property IBInspectable BOOL      borderTop;
 
--(id)initWithFrame:(CGRect)frame border:(Border)border radius:(double)radius color:(UIColor *)color borderWidth:(double)width;
+- (id)initWithFrame:(CGRect)frame border:(Border)border radius:(CGFloat)radius color:(UIColor *)color borderWidth:(CGFloat)width;
 - (void)updateView;
 
 @end

--- a/CCMBorderView/Objective-C/CCMBorderView.m
+++ b/CCMBorderView/Objective-C/CCMBorderView.m
@@ -35,7 +35,7 @@
     }
     return self;
 }
--(id)initWithFrame:(CGRect)frame border:(Border)border radius:(double)radius color:(UIColor *)color borderWidth:(double)width{
+- (id)initWithFrame:(CGRect)frame border:(Border)border radius:(CGFloat)radius color:(UIColor *)color borderWidth:(CGFloat)width {
     self = [super initWithFrame:frame];
     if (self) {
         if ((border & Border_Bottom) != 0) {
@@ -143,11 +143,11 @@
     }
 }
 
--(double)borderWidth{
+- (CGFloat)borderWidth {
     return _borderWidth;
 }
 
--(void)setBorderWidth:(double)borderWidth{
+- (void)setBorderWidth:(CGFloat)borderWidth {
     _borderWidth = borderWidth;
     [self updateView];
 }
@@ -165,11 +165,11 @@
 //    [self updateView];
 //}
 
--(double)cornerRadius{
+- (CGFloat)cornerRadius {
     return _cornerRadius;
 }
 
--(void)setCornerRadius:(double)cornerRadius{
+- (void)setCornerRadius:(CGFloat)cornerRadius {
     _cornerRadius = cornerRadius;
     [self updateView];
 }


### PR DESCRIPTION
To avoid warnings on conflicting return type of `borderWidth` and `cornerRadius` in some circumstances.
